### PR TITLE
Implemented ORIGINAL_RESERVED_BLOCKS_PERCENTAGE in metadata.txt

### DIFF
--- a/.bin/repack-erofs.sh
+++ b/.bin/repack-erofs.sh
@@ -475,7 +475,7 @@ create_ext4_flexible() {
     # Format with optimal settings
     if [ "$FILESYSTEM_TYPE" == "ext4" ] && [ -n "$ORIGINAL_UUID" ]; then
         # Preserve original filesystem characteristics when available
-        mkfs.ext4 -q -b 4096 -I "$ORIGINAL_INODE_SIZE" -U "$ORIGINAL_UUID" -L "$ORIGINAL_VOLUME_NAME" -O "$ORIGINAL_FEATURES" "$output_img"
+        mkfs.ext4 -q -b 4096 -I "$ORIGINAL_INODE_SIZE" -m "$ORIGINAL_RESERVED_BLOCKS_PERCENTAGE" -U "$ORIGINAL_UUID" -L "$ORIGINAL_VOLUME_NAME" -O "$ORIGINAL_FEATURES" "$output_img"
     else
         # Use optimized defaults for new filesystem
         mkfs.ext4 -q -b 4096 -i 16384 -m 1 -O ^has_journal,^resize_inode,dir_index,extent,sparse_super "$output_img"
@@ -726,7 +726,7 @@ case $FS_CHOICE in
 
                 echo -e "${BLUE}  - Creating temporary well-sized image...${RESET}"
                 dd if=/dev/zero of="$OUTPUT_IMG" bs="4096" count=$target_blocks status=none
-                mkfs.ext4 -q -b "4096" -I "$ORIGINAL_INODE_SIZE" -N "$ORIGINAL_INODE_COUNT" -U "$ORIGINAL_UUID" -L "$ORIGINAL_VOLUME_NAME" -O "$features_for_mkfs" "$OUTPUT_IMG"
+                mkfs.ext4 -q -b "4096" -m "$ORIGINAL_RESERVED_BLOCKS_PERCENTAGE" -I "$ORIGINAL_INODE_SIZE" -N "$ORIGINAL_INODE_COUNT" -U "$ORIGINAL_UUID" -L "$ORIGINAL_VOLUME_NAME" -O "$features_for_mkfs" "$OUTPUT_IMG"
                 mount -o loop,rw "$OUTPUT_IMG" "$MOUNT_POINT"
 
             else
@@ -736,7 +736,7 @@ case $FS_CHOICE in
                     features+=",^has_journal"
                 fi
                 dd if=/dev/zero of="$OUTPUT_IMG" bs="$ORIGINAL_BLOCK_SIZE" count="$ORIGINAL_BLOCK_COUNT" status=none
-                mkfs.ext4 -q -b "$ORIGINAL_BLOCK_SIZE" -I "$ORIGINAL_INODE_SIZE" -N "$ORIGINAL_INODE_COUNT" -U "$ORIGINAL_UUID" -L "$ORIGINAL_VOLUME_NAME" -O "$features" "$OUTPUT_IMG"
+                mkfs.ext4 -q -b "$ORIGINAL_BLOCK_SIZE" -m "$ORIGINAL_RESERVED_BLOCKS_PERCENTAGE" -I "$ORIGINAL_INODE_SIZE" -N "$ORIGINAL_INODE_COUNT" -U "$ORIGINAL_UUID" -L "$ORIGINAL_VOLUME_NAME" -O "$features" "$OUTPUT_IMG"
                 mount -o loop,rw,seclabel "$OUTPUT_IMG" "$MOUNT_POINT"
             fi
         fi

--- a/.bin/unpack-erofs.sh
+++ b/.bin/unpack-erofs.sh
@@ -587,7 +587,8 @@ if [ "$SOURCE_FS_TYPE" == "ext4" ]; then
     
     mounted_image=$(findmnt -n -o SOURCE --target "$MOUNT_DIR")
     
-    echo "ORIGINAL_BLOCK_COUNT=$(get_fs_param "$mounted_image" "Block count")" >> "${REPACK_INFO}/metadata.txt"
+    BLOCK_COUNT=$(get_fs_param "$mounted_image" "Block count")
+    echo "ORIGINAL_BLOCK_COUNT=$BLOCK_COUNT" >> "${REPACK_INFO}/metadata.txt"
     echo "ORIGINAL_BLOCK_SIZE=$(get_fs_param "$mounted_image" "Block size")" >> "${REPACK_INFO}/metadata.txt"    
     echo "ORIGINAL_INODE_COUNT=$(get_fs_param "$mounted_image" "Inode count")" >> "${REPACK_INFO}/metadata.txt"
     echo "ORIGINAL_UUID=$(get_fs_param "$mounted_image" "Filesystem UUID")" >> "${REPACK_INFO}/metadata.txt"
@@ -595,6 +596,12 @@ if [ "$SOURCE_FS_TYPE" == "ext4" ]; then
     echo "ORIGINAL_INODE_SIZE=$(get_fs_param "$mounted_image" "Inode size")" >> "${REPACK_INFO}/metadata.txt"
     FEATURES=$(tune2fs -l "$mounted_image" 2>/dev/null | grep "Filesystem features:" | awk -F':' '{print $2}' | xargs | sed 's/ /,/g')
     echo "ORIGINAL_FEATURES=$FEATURES" >> "${REPACK_INFO}/metadata.txt"
+    
+    RESERVED_BLOCKS_COUNT=$(get_fs_param "$mounted_image" "Reserved block count")
+    # Round up to the nearest integer percentage ( using the (a+b-1)/b formula to round up a/b in truncating arithmetic )
+    RESERVED_BLOCKS_PERCENTAGE=$(awk -v r="$RESERVED_BLOCKS_COUNT" -v b="$BLOCK_COUNT" 'BEGIN { printf("%d", (100*r + b - 1) / b) }')
+    echo "ORIGINAL_RESERVED_BLOCKS_PERCENTAGE=$RESERVED_BLOCKS_PERCENTAGE" >> "${REPACK_INFO}/metadata.txt"
+    
 fi
 
 echo ""


### PR DESCRIPTION
Implemented ORIGINAL_RESERVED_BLOCKS_PERCENTAGE in metadata.txt in order to preserve the original reserved blocks.

As documented in #8, running with the default 5% value was causing issues when running resize2fs in the shared blocks strict mode.

This PR proposes to simply extract the `RESERVED_BLOCKS_COUNT` in the unpacking phase, calculate the `RESERVED_BLOCKS_PERCENTAGE` by the formula `ceil(100* RESERVED_BLOCKS_COUNT / BLOCK_COUNT)`, save `RESERVED_BLOCKS_PERCENTAGE` to `metadata.txt` and then set it in the `mkfs.ext4` command when repacking via the `-m` parameter.