### PR TITLE
Bugfix: Escaped rel_path in restore_attributes() when used in grep -E regexes

### DIFF
--- a/.bin/repack-erofs.sh
+++ b/.bin/repack-erofs.sh
@@ -242,11 +242,12 @@ restore_attributes() {
         processed=$((processed + 1))
         percentage=$((processed * 100 / DIR_COUNT))
         rel_path=${item#$1}
+        rel_path_escaped=$(printf '%s' "$rel_path" | sed 's/[.[\*^$()+?{|}]/\\&/g')
         [ -z "$rel_path" ] && rel_path="/"
         
         # Use awk for robust parsing
-        stored_attrs=$(grep -E "^${rel_path} " "$FS_CONFIG_FILE" | head -n1 | awk '{$1=""; print $0}' | sed 's/^ //')
-        stored_context=$(grep -E "^${rel_path} " "$FILE_CONTEXTS_FILE" | head -n1 | awk '{$1=""; print $0}' | sed 's/^ //')
+        stored_attrs=$(grep -E "^${rel_path_escaped} " "$FS_CONFIG_FILE" | head -n1 | awk '{$1=""; print $0}' | sed 's/^ //')
+        stored_context=$(grep -E "^${rel_path_escaped} " "$FILE_CONTEXTS_FILE" | head -n1 | awk '{$1=""; print $0}' | sed 's/^ //')
 
         if [ -z "$stored_attrs" ]; then
             # New directory: find attributes from the closest known ancestor
@@ -285,9 +286,10 @@ restore_attributes() {
         processed=$((processed + 1))
         percentage=$((processed * 100 / FILE_COUNT))
         rel_path=${item#$1}
+        rel_path_escaped=$(printf '%s' "$rel_path" | sed 's/[.[\*^$()+?{|}]/\\&/g')
         
-        stored_attrs=$(grep -E "^${rel_path} " "$FS_CONFIG_FILE" | head -n1 | awk '{$1=""; print $0}' | sed 's/^ //')
-        stored_context=$(grep -E "^${rel_path} " "$FILE_CONTEXTS_FILE" | head -n1 | awk '{$1=""; print $0}' | sed 's/^ //')
+        stored_attrs=$(grep -E "^${rel_path_escaped} " "$FS_CONFIG_FILE" | head -n1 | awk '{$1=""; print $0}' | sed 's/^ //')
+        stored_context=$(grep -E "^${rel_path_escaped} " "$FILE_CONTEXTS_FILE" | head -n1 | awk '{$1=""; print $0}' | sed 's/^ //')
 
         if [ -z "$stored_attrs" ]; then
             # New file: find ownership/context from the closest known ancestor


### PR DESCRIPTION
- My `vendor_a.img` contained a file named `/lib64/libc++.so`.
- This file had gid 0 set in `fs-config` (which was correct), however after repacking it would somehow end up with a gid of 2000
- I noticed `rel_path` in restore_attributes() would get set to the value `"/lib64/libc++.so"` and then used in the line:
```shell
stored_context=$(grep -E "^${rel_path} " "$FILE_CONTEXTS_FILE" | head -n1 | awk '{$1=""; print $0}' | sed 's/^ //')
```
- Since `grep -E "^/lib64/libc++.so "` would be treated as a regular expression, the `++` would get interpreted as regex characters and the whole grep expression would return nothing, thus failing to restore the original context on the file.

This PR proposes a fix. It basically just escapes the special characters in `rel_path`.