### PR TITLE
Allow group max size to grow if it exceeds the saved size for virtual-ab

### DIFF
--- a/.bin/super-tools.sh
+++ b/.bin/super-tools.sh
@@ -305,7 +305,7 @@ run_repack() {
         done
         
         # Use saved group size for virtual-ab (preserves original layout), calculated size otherwise
-        if [ "$VIRTUAL_AB" = "true" ] && [ -n "$saved_group_size" ] && [ "$saved_group_size" -gt 0 ]; then
+        if [ "$VIRTUAL_AB" = "true" ] && [ -n "$saved_group_size" ] && [ "$saved_group_size" -gt "$total_group_size" ]; then
             total_group_size=$saved_group_size
         fi
         group_sizes[$group]=$total_group_size


### PR DESCRIPTION
- For virtual-ab, when the sum of the sizes of the edited partitions exceeds the saved group size, the super.img repack fails with the following error:
<img width="867" height="485" alt="Screenshot 2025-12-01 094843" src="https://github.com/user-attachments/assets/ac09090f-1320-424b-9f9f-89d328924ff3" />

- This PR proposes a fix which allows the group max sizes to be equal to the calculated total size when totalCalculatedSize > savedSize

closes #7 